### PR TITLE
fix(README): Replace placeholder username with the correct repository…

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To integrate RatingsKit into your Xcode project using Swift Package Manager, add
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/yourusername/RatingsKit.git", from: "1.0.0")
+    .package(url: "https://github.com/Sedlacek-Solutions/RatingsKit.git", from: "1.0.0")
 ]
 ```
 


### PR DESCRIPTION
Fix Swift Package Manager dependency URL in README

This PR corrects the Swift Package Manager dependency URL in the README. The previous version contained a placeholder (yourusername) instead of the actual repository owner’s username. This could lead to confusion or errors when adding the package.

The updated URL now correctly reflects the repository location, ensuring that users can add the dependency without issues.