### PR TITLE
Fix building error in Xcode 26

### DIFF
--- a/Sources/RatingsKit/Resources/Strings/Date+RelativeTime.swift
+++ b/Sources/RatingsKit/Resources/Strings/Date+RelativeTime.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import SwiftUICore
+import SwiftUI
 
 extension Date {
     /// Returns a localized relative time string using the LocalizedStringKey extension

--- a/Sources/RatingsKit/Resources/Strings/LocalizedStringKey+.swift
+++ b/Sources/RatingsKit/Resources/Strings/LocalizedStringKey+.swift
@@ -4,7 +4,7 @@
 //  Created by James Sedlacek on 2/1/25.
 //
 
-import SwiftUICore
+import SwiftUI
 
 @MainActor
 extension LocalizedStringKey {


### PR DESCRIPTION
Fixes compile-time errors that appear when building the library with Xcode 26 beta (17A5241e) while keeping full compatibility with Xcode 16.4.

<img width="800" alt="error" src="https://github.com/user-attachments/assets/e49cf1e0-9ed2-4302-9bd6-3a59d8327948" />
